### PR TITLE
Fixes table-of-contents.html closing tag

### DIFF
--- a/source/theme/templates/table-of-contents.html
+++ b/source/theme/templates/table-of-contents.html
@@ -234,7 +234,7 @@
      <h4 class="toc-subsection">9.3 <a href="/no-sql-datastore.html">NoSQL</a></h4>
      <div class="toc"><a href="/redis.html">Redis</a></div>
      <div class="toc"><a href="/mongodb.html">MongoDB</a></div>
-     <div class="toc"><a href="/apache-cassandra.html">Apache Cassandra</div>
+     <div class="toc"><a href="/apache-cassandra.html">Apache Cassandra</a></div>
      <div class="toc coming-soon">Neo4j</div>
 
      <h4 class="toc-subsection">9.4 <span class="coming-soon">Data analysis</span></h4>


### PR DESCRIPTION
A closing tag on Apache Cassandra link was missing and has been added.

Signed-off-by: Matthieu Berjon <matthieu@berjon.net>