### PR TITLE
Update template-engines.html

### DIFF
--- a/template-engines.html
+++ b/template-engines.html
@@ -114,7 +114,7 @@ in addition to supporting (as of Django 1.9) drop-in replacement with other
 template engines such as Jinja.</p>
 <h3>Mako</h3>
 <p><a href="/mako.html">Mako</a> is the default templating engine for the 
-<a href="/pyramid.html">Pyramid web framework</a> and has wide support as a replacement
+Pylons web framework and has wide support as a replacement
 template engine for many <a href="/other-web-frameworks.html">other web frameworks</a>.</p>
 <h3>Other Python template engine implementations</h3>
 <p>There are numerous Python template engine implementations that range from


### PR DESCRIPTION
Mako IS NOT the default in Pyramid, it was one of the options in the past (along with chameleon if memory serves me right), and was default in Pylons Web Framework. Default projects in Pyramid use Jinja2.