### PR TITLE
Add db name to psql command

### DIFF
--- a/content/posts/160518-install-postgresql-python-3-ubuntu-1604.markdown
+++ b/content/posts/160518-install-postgresql-python-3-ubuntu-1604.markdown
@@ -92,7 +92,7 @@ The `psql` command line client is useful for connecting directly to our
 PostgreSQL server without any Python code. Try out `psql` by using this
 command at the prompt: 
 
-    psql
+    psql testpython
 
 The PostgreSQL client will connect to the localhost server. The client is
 now ready for input:


### PR DESCRIPTION
Without the database name, the psql command returns: `psql: FATAL:  database "matt" does not exist.` The required command is "psql testpython", as shown (subtly) in the image below the edited line.