### PR TITLE
makes username regex capture group non-greedy, fixes #150

### DIFF
--- a/content/posts/160604-build-first-slack-bot-python.markdown
+++ b/content/posts/160604-build-first-slack-bot-python.markdown
@@ -128,7 +128,7 @@ variable values and then instantiate the Slack client.
     # constants
     RTM_READ_DELAY = 1 # 1 second delay between reading from RTM
     EXAMPLE_COMMAND = "do"
-    MENTION_REGEX = "^<@(|[WU].+)>(.*)"
+    MENTION_REGEX = "^<@(|[WU].+?)>(.*)"
 
 
 The code instantiates the `SlackClient` client with our `SLACK_BOT_TOKEN`
@@ -263,7 +263,7 @@ starterbot_id = None
 # constants
 RTM_READ_DELAY = 1 # 1 second delay between reading from RTM
 EXAMPLE_COMMAND = "do"
-MENTION_REGEX = "^<@(|[WU].+)>(.*)"
+MENTION_REGEX = "^<@(|[WU].+?)>(.*)"
 
 def parse_bot_commands(slack_events):
     """


### PR DESCRIPTION
the greedy matching would result in the wrong mention parsing if another formatted link was in the message. this change makes it non-greedy.

fixes #150 