### PR TITLE
Remove duplicated link

### DIFF
--- a/content/pages/02-development-environments/03-vim.markdown
+++ b/content/pages/02-development-environments/03-vim.markdown
@@ -129,10 +129,6 @@ to get started with these tutorials.
   shows how he configures and uses the editor so it sticks as his primary
   code editing tool.
 
-* [Why Atom Can't Replace Vim](https://medium.com/@mkozlows/why-atom-cant-replace-vim-433852f4b4d1)
-  explains how the composability of Vim and the extensibility of Emacs
-  allow both editors to remain relevant and very useful in the 21st century.
-
 * [Things About Vim I Wish I Knew Earlier](https://blog.petrzemek.net/2016/04/06/things-about-vim-i-wish-i-knew-earlier/)
   explores the lessons one developer learned while exclusively using Vim
   for several years. The author includes using relative instead of absolute


### PR DESCRIPTION
Remove 'Why Atom Can't Replace Vim' link and description