### PR TITLE
Update pypi links with new hostname

### DIFF
--- a/content/pages/02-development-environments/14-pymux.markdown
+++ b/content/pages/02-development-environments/14-pymux.markdown
@@ -8,7 +8,7 @@ meta: Pymux is a terminal multiplexer implementation written entirely in Python 
 
 
 # Pymux
-[Pymux](https://pypi.python.org/pypi/pymux)
+[Pymux](https://pypi.org/project/pymux)
 ([source code](https://github.com/jonathanslenders/pymux)) is a
 [terminal multiplexer](/terminal-multiplexers.html) implementation 
 written in Python that clones the functionality of [tmux](/tmux.html).
@@ -20,7 +20,7 @@ Pymux is less frequently used than tmux but it can be useful if you
 want to customize your own terminal multiplexer environment using 
 Python rather than digging into tmux's C code base.
 
-<a href="https://pypi.python.org/pypi/pymux" style="border:none"><img src="/img/visuals/pymux.png" width="100%" alt="Screenshot of Pymux running with multiple shell sessions." class="shot outl"></a>
+<a href="https://pypi.org/project/pymux" style="border:none"><img src="/img/visuals/pymux.png" width="100%" alt="Screenshot of Pymux running with multiple shell sessions." class="shot outl"></a>
 
 <div class="well see-also">Pymux is an implementation of the <a href="/terminal-multiplexers.html">terminal multiplexers</a> concept. Learn more in the <a href="/development-environments.html">development environments</a> chapter or view the <a href="/table-of-contents.html">table of contents</a> for all topics.</div> 
 

--- a/content/pages/03-data/01-databases.markdown
+++ b/content/pages/03-data/01-databases.markdown
@@ -105,7 +105,7 @@ library. The most common libraries for relational databases are:
   ([source code](https://github.com/psycopg/psycopg2))
   for PostgreSQL.
 
-* [MySQLdb](https://pypi.python.org/pypi/MySQL-python/1.2.5) 
+* [MySQLdb](https://pypi.org/project/MySQL-python/1.2.5) 
   ([source code](https://github.com/farcepest/MySQLdb1)) 
   for MySQL. Note that this driver's development is mostly frozen so
   evaluating alternative drivers is wise if you are using 

--- a/content/pages/03-data/02-postgresql.markdown
+++ b/content/pages/03-data/02-postgresql.markdown
@@ -138,7 +138,7 @@ walkthroughs I've read.
 * [How to speed up tests in Django and PostgreSQL](http://nemesisdesign.net/blog/coding/how-to-speed-up-tests-django-postgresql/)
   explains some hacks for making your schema migration-backed run quicker.
 
-* [Records](https://pypi.python.org/pypi/records/) is a wrapper around the psycopg2
+* [Records](https://pypi.org/project/records/) is a wrapper around the psycopg2
   driver that allows easy access to direct SQL access. It's worth a look if
   you prefer writing SQL over using an 
   [ORM](/object-relational-mappers-orms.html) like SQLAlchemy.

--- a/content/pages/03-data/03-mysql.markdown
+++ b/content/pages/03-data/03-mysql.markdown
@@ -32,10 +32,10 @@ driver.
 
 There was a major issue with MySQL drivers since the introduction of 
 Python 3. One of the most popular libraries called 
-[MySQLdb](https://pypi.python.org/pypi/MySQL-python/1.2.5) did not work
+[MySQLdb](https://pypi.org/project/MySQL-python/1.2.5) did not work
 in its existing form with Python 3 and there were no plans to update it.
 Therefore a fork of MySQLdb named 
-[mysqlclient](https://pypi.python.org/pypi/mysqlclient) added Python 3
+[mysqlclient](https://pypi.org/project/mysqlclient) added Python 3
 compatibility. 
 
 The mysqlclient fork was good in that existing MySQLdb users could drop
@@ -49,7 +49,7 @@ With that driver support context in mind, it's absolutely possible to build
 a Python 3 web application with MySQL as a backend. Here is a list of
 drivers along with whether it supports Python 2, 3 or both.
 
-* [mysqlclient](https://pypi.python.org/pypi/mysqlclient) is a fork
+* [mysqlclient](https://pypi.org/project/mysqlclient) is a fork
   of MySQLdb that supports Python 2 and 3.
 
 * [MySQL Connector](http://dev.mysql.com/doc/connector-python/en/)
@@ -58,7 +58,7 @@ drivers along with whether it supports Python 2, 3 or both.
   [version guide](http://dev.mysql.com/doc/connector-python/en/) for what
   releases work with which Python versions.
 
-* [MySQLdb](https://pypi.python.org/pypi/MySQL-python/1.2.5) supports
+* [MySQLdb](https://pypi.org/project/MySQL-python/1.2.5) supports
   Python 2 and was frequently used by Python web applications before the
   mass migration to Python 3 began.
 

--- a/content/pages/03-data/05-object-relational-mappers.markdown
+++ b/content/pages/03-data/05-object-relational-mappers.markdown
@@ -66,7 +66,7 @@ Python ORM libraries are not required for accessing relational
 databases. In fact, the low-level access is typically provided by another
 library called a *database connector*, such as
 [psycopg](http://initd.org/psycopg/) (for PostgreSQL)
-or [MySQL-python](https://pypi.python.org/pypi/MySQL-python/1.2.5) (for
+or [MySQL-python](https://pypi.org/project/MySQL-python/1.2.5) (for
 MySQL). Take a look at the table below which shows how ORMs can work with
 different web frameworks and connectors and relational databases.
 

--- a/content/pages/03-data/06-sqlalchemy.markdown
+++ b/content/pages/03-data/06-sqlalchemy.markdown
@@ -116,7 +116,7 @@ your application's code with the SQLAlchemy library.
 * [Morepath](/morepath.html) has easy-to-use support for SQLAlchemy via its
   [more.transaction](http://blog.startifact.com/posts/racing-the-morepath-sqlalchemy-integration.html) 
   module. There is a 
-  [morepath-sqlalchemy demo](https://pypi.python.org/pypi/morepath-sqlalchemy/)
+  [morepath-sqlalchemy demo](https://pypi.org/project/morepath-sqlalchemy/)
   that serves as a working example.
 
 
@@ -162,7 +162,7 @@ edge cases.
 
 * [Getting PostgreSQL transactions under control with SQLAlchemy](http://layer0.authentise.com/getting-postgresql-transactions-under-control-with-sqlalchemy.html)
   provides a quick introduction to the tool 
-  [Chryso](https://pypi.python.org/pypi/chryso/) that they are working on
+  [Chryso](https://pypi.org/project/chryso/) that they are working on
   to provide better transaction management in SQLAlchemy connections.
 
 

--- a/content/pages/04-web-development/02-django.markdown
+++ b/content/pages/04-web-development/02-django.markdown
@@ -22,7 +22,7 @@ For example,
 [template engine](/django-templates.html),
 an [object-relational mapper](/object-relational-mappers-orms.html) (ORM),
 and [database schema migrations](https://docs.djangoproject.com/en/dev/topics/migrations/)
-(as of version 1.7) are all included with the [Django framework](https://pypi.python.org/pypi/Django/). 
+(as of version 1.7) are all included with the [Django framework](https://pypi.org/project/Django/). 
 Compare that included functionality to the Flask framework which requires a 
 separate library such as 
 [Flask-Login](https://flask-login.readthedocs.org/en/latest/)

--- a/content/pages/04-web-development/11-template-engines.markdown
+++ b/content/pages/04-web-development/11-template-engines.markdown
@@ -121,7 +121,7 @@ engines are listed alphabetically:
 
 * [Diazo](http://docs.diazo.org/en/latest/)
 
-* [evoque](https://pypi.python.org/pypi/evoque/)
+* [evoque](https://pypi.org/project/evoque/)
 
 * [Genshi](https://genshi.edgewall.org/)
 
@@ -129,7 +129,7 @@ engines are listed alphabetically:
 
 * [Myghty](https://pythonhosted.org/Myghty/whatsitdo.html)
 
-* [pyratemp](https://pypi.python.org/pypi/pyratemp/0.3.2)
+* [pyratemp](https://pypi.org/project/pyratemp/0.3.2)
 
 * [pystache](https://github.com/defunkt/pystache)
 

--- a/content/pages/04-web-development/42-code-metrics.markdown
+++ b/content/pages/04-web-development/42-code-metrics.markdown
@@ -24,11 +24,11 @@ system are occurring.
   obtaining raw metrics on line counts, Cyclomatic Complexity, Halstead
   metrics and maintainability metrics.
 
-* [Pylint](http://www.pylint.org/) contains checkers for PEP8 code 
+* [Pylint](https://pypi.org/project/pylint/) contains checkers for PEP8 code 
   style compliance, design, exceptions and many other source code analysis
   tools.
 
-* [PyFlakes](https://pypi.python.org/pypi/pyflakes) parses source files for
+* [PyFlakes](https://pypi.org/project/pyflakes/) parses source files for
   errors and reports on them.
 
 * [Pyntch](http://www.unixuser.org/~euske/python/pyntch/index.html) is a

--- a/content/pages/04-web-development/55-api-creation.markdown
+++ b/content/pages/04-web-development/55-api-creation.markdown
@@ -171,7 +171,7 @@ equivalent of browser testing in the web application world.
 * [Create a REST API in Minutes with Pyramid and Ramses](https://realpython.com/blog/python/create-a-rest-api-in-minutes-with-pyramid-and-ramses/)
   is a thorough tutorial from start to finish that uses the 
   [Pyramid](/pyramid.html) web framework along with 
-  [Ramses](https://pypi.python.org/pypi/ramses/), a library that uses
+  [Ramses](https://pypi.org/project/ramses/), a library that uses
   YAML files to generate a RESTful API.
 
 * [RESTful web services with Python](http://www.slideshare.net/Solution4Future/python-restful-webservices-with-python-flask-and-django-solutions)

--- a/content/posts/160510-flask-gunicorn-ubuntu-1604.markdown
+++ b/content/posts/160510-flask-gunicorn-ubuntu-1604.markdown
@@ -77,7 +77,7 @@ Python-specific dependencies.
 
 ## Virtualenv
 In the previous section, [virtualenv](https://virtualenv.pypa.io/en/latest/) 
-and [pip](https://pypi.python.org/pypi/pip) were installed to handle our 
+and [pip](https://pypi.org/project/pip) were installed to handle our 
 [application dependencies](/application-dependencies.html).
 We can now use them to download and install Flask and Gunicorn.
 

--- a/content/posts/160511-send-sms-text-message-python.markdown
+++ b/content/posts/160511-send-sms-text-message-python.markdown
@@ -28,7 +28,7 @@ those two versions installed.
 * A free [Twilio account](https://www.twilio.com/try-twilio) to use their 
   [SMS web API](https://www.twilio.com/docs/api/rest/sending-messages)
 * Open source 
-  [Twilio Python helper library](https://pypi.python.org/pypi/twilio),
+  [Twilio Python helper library](https://pypi.org/project/twilio),
   [version 6.0.0](https://github.com/twilio/twilio-python/tree/6.0.0) 
   or later
 

--- a/content/posts/160513-bottle-gunicorn-ubuntu-1604.markdown
+++ b/content/posts/160513-bottle-gunicorn-ubuntu-1604.markdown
@@ -78,7 +78,7 @@ Python-specific dependencies.
 
 ## Virtualenv
 In the previous section, [virtualenv](https://virtualenv.pypa.io/en/latest/) 
-and [pip](https://pypi.python.org/pypi/pip) were installed to handle our 
+and [pip](https://pypi.org/project/pip) were installed to handle our 
 [application dependencies](/application-dependencies.html).
 We can now use them to download and install Bottle and Gunicorn.
 

--- a/content/posts/160515-sending-mms-picture-messages-python.markdown
+++ b/content/posts/160515-sending-mms-picture-messages-python.markdown
@@ -30,7 +30,7 @@ The other dependencies for this tutorial include:
   [application dependency](/application-dependencies.html)
 * A free [Twilio account](https://www.twilio.com/try-twilio) to use their 
   [MMS web API](https://www.twilio.com/docs/api/rest/sending-messages)
-* [Twilio Python helper library](https://pypi.python.org/pypi/twilio),
+* [Twilio Python helper library](https://pypi.org/project/twilio),
   [version 6.0.0](https://github.com/twilio/twilio-python/tree/6.0.0) 
   or later
 
@@ -64,7 +64,7 @@ in the phone number details screen.
 
 
 ## Installing Our Dependency
-We'll use the [twilio helper library](https://pypi.python.org/pypi/twilio) 
+We'll use the [twilio helper library](https://pypi.org/project/twilio) 
 as a dependency for our Python code. The helper library can be installed
 via the `pip` command, which pulls the code from 
 [PyPI](https://pypi.python.org/pypi) into our local virtualenv. In this

--- a/content/posts/160518-install-postgresql-python-3-ubuntu-1604.markdown
+++ b/content/posts/160518-install-postgresql-python-3-ubuntu-1604.markdown
@@ -32,7 +32,7 @@ the Python interpreter, here are the other components we'll use:
   steps should also work fine with other Ubuntu versions)
 * [pip](https://pip.pypa.io/en/stable/) and 
   [virtualenv](https://virtualenv.pypa.io/en/latest/) to handle the
-  [psycopg2](https://pypi.python.org/pypi/psycopg2/2.6.1) 
+  [psycopg2](https://pypi.org/project/psycopg2/2.6.1) 
   [application dependency](/application-dependencies.html)
 * [PostgreSQL](http://www.postgresql.org/)
 

--- a/content/posts/160530-respond-sms-text-messages-python-flask.markdown
+++ b/content/posts/160530-respond-sms-text-messages-python-flask.markdown
@@ -29,7 +29,7 @@ those two versions installed on your system.
 * A free [Twilio account](https://www.twilio.com/try-twilio) to use their 
   [SMS web API](https://www.twilio.com/docs/api/rest/sending-messages)
 * Open source 
-  [Twilio Python helper library](https://pypi.python.org/pypi/twilio)
+  [Twilio Python helper library](https://pypi.org/project/twilio)
 * [Ngrok](https://ngrok.com/) for localhost tunneling to our Flask 
   application while it's running on our local development environment
 

--- a/content/posts/160605-reply-sms-python-bottle.markdown
+++ b/content/posts/160605-reply-sms-python-bottle.markdown
@@ -33,7 +33,7 @@ walkthrough. We also need:
 * Free [Twilio account](https://www.twilio.com/try-twilio) to use their 
   [SMS web API](https://www.twilio.com/docs/api/rest/sending-messages)
 * Open source 
-  [Twilio Python helper library](https://pypi.python.org/pypi/twilio),
+  [Twilio Python helper library](https://pypi.org/project/twilio),
   version 5.7.0 or earlier
 
 Check out the guide on 

--- a/content/posts/160830-phone-calls-bottle.markdown
+++ b/content/posts/160830-phone-calls-bottle.markdown
@@ -34,7 +34,7 @@ applications. We also need:
 * Twilio's 
   [Python helper library](https://www.twilio.com/docs/libraries/python),
   which is [open source on GitHub](https://github.com/twilio/twilio-python) 
-  and [available for download from PyPI](https://pypi.python.org/pypi/twilio)
+  and [available for download from PyPI](https://pypi.org/project/twilio)
 
 Take a look at 
 [this guide on setting up Python 3, Bottle and Gunicorn on Ubuntu 16.04 LTS](/blog/python-3-bottle-gunicorn-ubuntu-1604-xenial-xerus.html)

--- a/content/posts/161123-make-phone-calls.markdown
+++ b/content/posts/161123-make-phone-calls.markdown
@@ -33,7 +33,7 @@ build this application. Throughout the post we will also use:
 * Twilio's 
   [Python helper library](https://www.twilio.com/docs/libraries/python),
   version 5.7.0, which is 
-  [available on PyPI](https://pypi.python.org/pypi/twilio)
+  [available on PyPI](https://pypi.org/project/twilio)
 
 You can snag all the open source code for this tutorial in the 
 [python-twilio-example-apps](https://github.com/mattmakai/python-twilio-example-apps/tree/master/no-framework/phone-calls)

--- a/content/posts/170723-monitor-flask-apps.markdown
+++ b/content/posts/170723-monitor-flask-apps.markdown
@@ -36,7 +36,7 @@ the post:
 * [pyrollbar](https://rollbar.com/docs/notifier/pyrollbar/) monitoring 
   instrumentation library,
   [version 0.13.12](https://github.com/rollbar/pyrollbar/tree/v0.13.12)
-* [blinker](https://pypi.python.org/pypi/blinker) for signaling support
+* [blinker](https://pypi.org/project/blinker) for signaling support
   in Flask applications so pyrollbar can report on all errors
 * A [free Rollbar account](https://rollbar.com/) where we will send error
   data and view it when it is captured

--- a/content/posts/180202-monitor-django-web-apps.markdown
+++ b/content/posts/180202-monitor-django-web-apps.markdown
@@ -81,8 +81,8 @@ The command prompt will change after activating the virtualenv:
 Remember that you need to activate your virtualenv in every new terminal 
 window where you want to use the virtualenv to run the project.
 
-We can now install the [Django](https://pypi.python.org/pypi/Django/2.0.4) 
-and [Rollbar](https://pypi.python.org/pypi/rollbar) packages into the 
+We can now install the [Django](https://pypi.org/project/Django/2.0.4) 
+and [Rollbar](https://pypi.org/project/rollbar) packages into the 
 activated, empty virtualenv.
 
 ```

--- a/content/posts/180519-django-maps-mapbox.markdown
+++ b/content/posts/180519-django-maps-mapbox.markdown
@@ -85,7 +85,7 @@ The command prompt will change after activating the virtualenv:
 Remember that you have to activate your virtualenv in every new terminal 
 window where you want to use dependencies in the virtualenv.
 
-We can now install the [Django](https://pypi.python.org/pypi/Django/2.0.5) 
+We can now install the [Django](https://pypi.org/project/Django/2.0.5) 
 package into the activated but otherwise empty virtualenv.
 
 ```


### PR DESCRIPTION
https://pypi.python.org now redirects to https://pypi.org/ - this pull request changes PyPi URLs to reflect the new hostname to avoid redirects from https://pypi.python.org.