### PR TITLE
Remove some more dead links

### DIFF
--- a/content/pages/01-introduction/10-best-python-podcasts.markdown
+++ b/content/pages/01-introduction/10-best-python-podcasts.markdown
@@ -160,9 +160,6 @@ data science broadly and often get specific into Python ecosystem tools.
   science podcast that often covers Python libraries and other areas of
   interest to people using Python to analyze [data](/data.html).
 
-* [Data Skeptic](https://dataskeptic.com/) covers data science, statistics, 
-  machine learning, artificial intelligence and "scientific skepticism".
-
 * [Data stories](http://datastori.es/) is a podcast on data visualization.
 
 * [Partially Derivative](http://partiallyderivative.com/) was a podcast for

--- a/content/pages/04-web-development/13-mako.markdown
+++ b/content/pages/04-web-development/13-mako.markdown
@@ -24,11 +24,6 @@ used to generate output HTML, XML and similar formats.
 * [Configuration Templates with Python and Mako](https://codingnetworker.com/2016/01/configuration-templates-python-mako/)
   shows some basic situations for how to use Mako in an example project.
 
-* The 
-  [Pylons' project documentation on templates](http://pylonsbook.com/en/1.1/using-view-templates.html)
-  provides many examples for using Mako, which is the default template 
-  language for the Pylons [web framework](/web-frameworks.html).
-
 * [Flask-Mako](https://pythonhosted.org/Flask-Mako/) is a [Flask](/flask.html) 
   extension that makes it easier to use Mako as the template engine in your
   Flask web app projects.


### PR DESCRIPTION
Minor changes since last time. I ran `check_urls` against these links a couple of times within the past 3 days just to make sure it wasn't a fluke.

Note: It turns out I still have to manually check the bad links dictionary since each link might get timeout due to a bad/slow network on my side and intermittent errors on the site. Nevertheless, the script is a good starting point for pinpointing errors since it tends to returns few results.

Note: The timeout threshold might need to be configurable in the future. Can also consider implementing retries for `GET` calls with backoff (tradeoff being slower execution).