### PR TITLE
Secure the password encryption of ssh key

### DIFF
--- a/content/posts/170214-create-ssh-keys-ubuntu.markdown
+++ b/content/posts/170214-create-ssh-keys-ubuntu.markdown
@@ -29,8 +29,10 @@ Optionally, you can also specify your email address with `-C` (otherwise
 one will be generated off your current Linux account):
 
 ```bash
-ssh-keygen -t rsa -b 4096 -C my.email.address@company.com
+ssh-keygen -o -t rsa -b 4096 -C my.email.address@company.com
 ```
+
+(Note: the `-o` option was introduced in 2014; if this command fails for you, simply remove the `-o` option)
 
 The first prompt you will see asks where to save the key. However, there are
 actually two files that will be generated: the public key and the private 


### PR DESCRIPTION
I found your guide on generating SSH keys (https://www.fullstackpython.com/blog/ssh-keys-ubuntu-linux.html) after looking at the top 20 Google results for 'how do I generate an ssh key', and it looks like your default suggestions for using ssh-keygen are insecure.

I highly recommend you add this to your guide's ssh-keygen arguments:

    ssh-keygen -o

    (Note: The -o option was added in 2014; if this command fails for you, simply remove the -o option)

This will ensure the key is password-encrypted properly.

From the ssh-keygen manual:

    -o      Causes ssh-keygen to save private keys using the new OpenSSH for‐
            mat rather than the more compatible PEM format.  The new format
            has increased resistance to brute-force password cracking but is
            not supported by versions of OpenSSH prior to 6.5.  Ed25519 keys
            always use the new private key format.

The problem is described in this blog post: https://latacora.singles/2018/08/03/the-default-openssh.html
More info can be found on this Hacker News thread: https://news.ycombinator.com/item?id=17682999

By making these changes to your guide, you will be making the internet safer. If the keys used to access servers are secure by default, then both the servers, and all the users who visit websites on those servers, will be more secure.

---

Here is some background on the problem:

  - By default, ssh-keygen will try password-protect the ssh key. But the default encoding for the password is actually very easy to crack. By using the -o argument you can change to a newer password encoding which is much more secure.

  - Using the default ssh-keygen options are worse than not providing a password at all. The password is so easy to crack that it can then be reused to attack other accounts that use this password. (See the Hacker News thead for more details)

  - The only downside to using -o is it may not work for versions of ssh-keygen older than 2014. You can therefore suggest the -o option, and suggest that if it does not work, that the user remove the -o option.


Additional recommendations:

  - Your users can upgrade their existing keys with improved password security with this command:

    ssh-keygen -p -o -f (oldfile)

  - If you are suggesting the RSA key type, please suggest the -b 4096 options. The reason is that as computers get faster, not only is this not as slow as it used to be, but the default smaller key length of 2048 gets easier to crack.

  - If your guide uses the PuTTYgen tool, please suggest 4096 for the number of bits in a generated key. The tool's default of 1024 is far too small to be secure.

Thank you very much for your consideration and help in this matter.
Please feel free to contact me if you have any questions.