### PR TITLE
Remove broken links from repo

### DIFF
--- a/content/pages/01-introduction/02-python-programming-language.markdown
+++ b/content/pages/01-introduction/02-python-programming-language.markdown
@@ -112,9 +112,6 @@ Dictionary comprehension:
 * [Writing idiomatic Python](http://www.jeffknupp.com/blog/2012/10/04/writing-idiomatic-python/)
   is a guide for writing Pythonic code.
 
-* [The thing that runs your Python](http://ashfall.github.io/blog/2012/10/23/the-thing-that-runs-your-python/)
-  is a summary of what one developer learned about PyPy while researching it. 
-
 
 ### Python ecosystem resources
 There's an entire page on [best Python resources](/best-python-resources.html)

--- a/content/pages/02-development-environments/03-emacs.markdown
+++ b/content/pages/02-development-environments/03-emacs.markdown
@@ -157,10 +157,6 @@ incorporate into their environment.
   and [Cheetah](https://pythonhosted.org/Cheetah/) as well as 
   [JavaScript](/javascript.html) front-end frameworks.
 
-* [Tern](http://ternjs.net/) is a stand-alone code-analysis engine for
-  JavaScript. It can be integrated within a Django project
-  via the [tern-django](https://github.com/proofit404/tern-django) package.
-
 
 ### Popular user configurations
 Numerous custom Emacs user configurations exist that bundle together custom

--- a/content/pages/02-development-environments/06-jupyter-notebook.markdown
+++ b/content/pages/02-development-environments/06-jupyter-notebook.markdown
@@ -184,7 +184,3 @@ like advanced interactive visualizations.
 * [Creating Presentations with Jupyter Notebook](http://www.blog.pythonlibrary.org/2018/09/25/creating-presentations-with-jupyter-notebook/)
   shows how to make slides out of your cells so you can present your
   work like a traditional presentation.
-
-* [Power-Ups for Jupyter Notebooks](https://towardsdatascience.com/power-ups-for-jupyter-notebooks-ebfa6e5e57a0)
-  gives an overview of helpful add ons, shortcuts and tricks that you
-  can use in your Jupyter Notebooks.

--- a/content/pages/03-data/08-django-orm.markdown
+++ b/content/pages/03-data/08-django-orm.markdown
@@ -63,11 +63,6 @@ that have been added throughout the project's history.
   [relational database](/databases.html) will require a lot more work to
   port over to another backend even with the power of the ORM.
 
-* [Django Model Descriptors](http://blog.kevinastone.com/django-model-descriptors.html)
-  discusses and shows how to incorporate business logic into Django models
-  to reduce complexity from the views and make the code easier to reuse across
-  separate views.
-
 * [Adding basic search to your Django site](https://www.calazan.com/adding-basic-search-to-your-django-site/)
   shows how to write generic queries that'll allow you to provide site
   search via the Django ORM without relying on another tool like

--- a/content/pages/04-web-development/02-django.markdown
+++ b/content/pages/04-web-development/02-django.markdown
@@ -278,10 +278,6 @@ Django developers. These resources along with the
 [static content](/static-content.html) page are useful for figuring out how 
 to handle these files properly.
 
-* [How to Optimize Images for Page Load Speed in Django](https://worthwhile.com/blog/2016/07/11/django-page-load-speed/)
-  reviews good practices for improving page speed performance when media 
-  images make up a significant percentage of webpage download size.
-
 * [Using Amazon S3 to Store your Django Site's Static and Media Files](http://www.caktusgroup.com/blog/2014/11/10/Using-Amazon-S3-to-store-your-Django-sites-static-and-media-files/)
   is a well written guide to a question commonly asked about static and
   media file serving.

--- a/content/pages/04-web-development/26-angular.markdown
+++ b/content/pages/04-web-development/26-angular.markdown
@@ -17,8 +17,6 @@ application framework for building rich apps that run in web browsers.
 
 
 ### Angular resources
-* [Getting Started with Django Rest Framework and AngularJS](http://blog.kevinastone.com/getting-started-with-django-rest-framework-and-angularjs.html)
-  is a very detailed introduction to Djangular with example code. 
 
 * This [end to end web app with Django-Rest-Framework & AngularJS part 1](http://mourafiq.com/2013/07/01/end-to-end-web-app-with-django-angular-1.html)
   tutorial along with 

--- a/content/pages/04-web-development/36-unit-testing.markdown
+++ b/content/pages/04-web-development/36-unit-testing.markdown
@@ -82,10 +82,6 @@ Python-specific applications.
 * The Python wiki has a page with a list of 
   [Python testing tools and extensions](https://wiki.python.org/moin/PythonTestingToolsTaxonomy).
 
-* [Generate your tests](http://blog.kevinastone.com/generate-your-tests.html)
-  shows how to write a test generator that works with the `unittest` 
-  framework.
-
 * [An Extended Introduction to the nose Unit Testing Framework](http://ivory.idyll.org/articles/nose-intro.html)
   shows how this test runner can be used to write basic test suites.
   While the article is from 2006, it remains relevant today for learning

--- a/content/pages/05-deployment/07-digitalocean.markdown
+++ b/content/pages/05-deployment/07-digitalocean.markdown
@@ -11,8 +11,6 @@ meta: DigitalOcean is a virtual private server provider and deployment platform 
 DigitalOcean is a virtual private server provider and deployment 
 platform that can be used for running Python applications.
 
-<a href="https://do.co/fsp" style="border: none;"><img src="/img/logos/digitalocean.png" width="100%" alt="Official DigitalOcean logo. Copyright DigitalOcean." class="shot" style="padding: 12px 0 12px 0"></a>
-
 
 ### DigitalOcean examples
 * [Creating a Kubernetes Cluster on DigitalOcean with Python and Fabric](https://testdriven.io/blog/creating-a-kubernetes-cluster-on-digitalocean/)

--- a/content/pages/06-devops/00-devops.markdown
+++ b/content/pages/06-devops/00-devops.markdown
@@ -59,11 +59,6 @@ teams, culture, processes and tools into software development organizations.
   their services running and putting them out for other developers to consume.
   Highly recommended.
 
-* [So, you've been paged](http://blog.scalyr.com/2016/09/so-youve-been-paged/)
-  provides their development team's "Communicate -> Learn -> Act" structure
-  for handling production issues based on lessons learned from their years 
-  of experience dealing with incidents.
-
 * [Operations for software developers for beginners](https://jvns.ca/blog/2016/10/15/operations-for-software-developers-for-beginners/)
   gives advice to developers who have never done operations work and
   been on call for outages before in their career. The advantage of DevOps


### PR DESCRIPTION
Here are some more links that I found. Feel free to review them over again before approving the request. Some notable ones:

- The tern.js doesn't seem to have Django support anymore (at least the `tern_django` GitHub repo is down for good)
- There was an outdated link to a DigitalOcean discount. Not sure whether the link path is deprecated or that the discount is no longer applicable