### PR TITLE
Remove bad links from content via check_urls

### DIFF
--- a/content/pages/01-introduction/04-python-2-or-3.markdown
+++ b/content/pages/01-introduction/04-python-2-or-3.markdown
@@ -75,10 +75,6 @@ gone through the process and have advice for making it less painful.
   implementations. There is also a 
   [quick reference for writting code with Python 2 and 3 compatibility](https://wiki.python.org/moin/PortingToPy3k/BilingualQuickRef).
 
-* [Django and Python 3 How to Setup pyenv for Multiple Pythons](https://godjango.com/96-django-and-python-3-how-to-setup-pyenv-for-multiple-pythons/)
-  is a screencast showing how to run both Python 2 and 3 for different
-  projects using pyenv.
-
 * [Upgrading to Python 3 with Zero Downtime](https://tech.yplanapp.com/2016/08/24/upgrading-to-python-3-with-zero-downtime/)
   supplies advice on transitioning a large existing Python 2 web application 
   to Python 3. Their process involved upgrading dependencies, testing and

--- a/content/pages/04-web-development/27-task-queues.markdown
+++ b/content/pages/04-web-development/27-task-queues.markdown
@@ -184,10 +184,6 @@ when scaling out a large deployment of distributed task queues.
   are things to keep in mind when you're new to the Celery task queue
   implementation.
 
-* [Deferred Tasks and Scheduled Jobs with Celery 3.1, Django 1.7 and Redis](https://godjango.com/63-deferred-tasks-and-scheduled-jobs-with-celery-31-django-17-and-redis/)
-  is a video along with code that shows how to set up Celery with Redis as the
-  broker in a Django application.
-
 * [Setting up an asynchronous task queue for Django using Celery and Redis](http://michal.karzynski.pl/blog/2014/05/18/setting-up-an-asynchronous-task-queue-for-django-using-celery-redis/)
   is a straightforward tutorial for setting up the Celery task queue for
   Django web applications using the Redis broker on the back end.

--- a/content/pages/04-web-development/45-microservices.markdown
+++ b/content/pages/04-web-development/45-microservices.markdown
@@ -124,7 +124,3 @@ ease further development and deployment. This approach is called the
 * [The Hardest Part About Microservices: Your Data](http://blog.christianposta.com/microservices/the-hardest-part-about-microservices-data/)
   presents a data-centric view on how to structure and transport data
   in a microservices architecture.
-
-* [Making microservices more resilient with circuit breakers](https://blog.buoyant.io/2017/01/13/making-microservices-more-resilient-with-circuit-breaking/)
-  provides a solid idea for how to handle issues with microservices so the
-  problems are less likely to cascade through your entire infrastructure.

--- a/content/pages/06-devops/18-web-analytics.markdown
+++ b/content/pages/06-devops/18-web-analytics.markdown
@@ -77,10 +77,6 @@ application before taking some action, such as purchasing your service.
   is a detailed walkthrough for collecting and analyzing webpage
   analytics with your own Flask app.
 
-* [Pandas and Google Analytics](http://blog.yhathq.com/posts/pandas-google-analytics.html)
-  shows how to use pandas for data analysis with Google Analytics' API to
-  perform calculations not available in the tool itself.
-
 * [Build a Google Analytics Slack Bot with Python](https://www.twilio.com/blog/2018/03/google-analytics-slack-bot-python.html)
   explains how to connect the Google Analytics API to a [Slack](/slack.html) 
   bot, with all the code in Python, so you can query for Google Analytics 


### PR DESCRIPTION
Linkerd seem to have taken down one of its articles. Furthermore, some S3 bucket content has been invalidated. Not too many links to clean up this time around, so that's a good sign.