### PR TITLE
Fix incorrect link in integration testing page

### DIFF
--- a/content/pages/04-web-development/37-integration-testing.markdown
+++ b/content/pages/04-web-development/37-integration-testing.markdown
@@ -32,7 +32,7 @@ during development so they can be addressed immediately.
 
 
 ### Integration testing resources
-* [Integration testing with Context Managers](http://eigenhombre.com/introduction-to-context-managers-in-python.html)
+* [Integration testing with Context Managers](http://eigenhombre.com/2013/04/13/integration-testing-in-python-with-context-managers)
   gives an example of a system that needs integration tests and shows how
   context managers can be used to address the problem.
 


### PR DESCRIPTION
Thank you for maintaining such a lovely website. :)

### Issue

On the page [Integration Testing](https://www.fullstackpython.com/integration-testing.html), the first resource links to a general page on context managers, rather than a link specific about integration testing.

### Changes made

Update link to point to correct guide on author's blog.